### PR TITLE
Fix errorprone error that causes robot code to brick

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,6 @@ dependencies {
 
 tasks.withType(JavaCompile).configureEach {
 	options.errorprone.disableWarningsInGeneratedCode = true
-	options.errorprone.excludedPaths = ".*/src/main/java/swervelib/.*"
 }
 
 test {


### PR DESCRIPTION
Before this fix robot code would not work on the robot, returning a `Could not find or load main class frc.team2412.robot.Main` error.