### PR TITLE
Add Spark PID controller widget

### DIFF
--- a/src/main/java/frc/team2412/robot/util/SparkPIDWidget.java
+++ b/src/main/java/frc/team2412/robot/util/SparkPIDWidget.java
@@ -1,0 +1,26 @@
+package frc.team2412.robot.util;
+
+import com.revrobotics.SparkPIDController;
+import edu.wpi.first.networktables.NTSendable;
+import edu.wpi.first.networktables.NTSendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
+
+public class SparkPIDWidget implements NTSendable {
+
+	public final SparkPIDController controller;
+
+	public SparkPIDWidget(SparkPIDController controller) {
+		this.controller = controller;
+
+		SendableRegistry.add(this, "Spark PID Controller");
+	}
+
+	@Override
+	public void initSendable(NTSendableBuilder builder) {
+		builder.setSmartDashboardType("PIDController");
+
+		builder.addDoubleProperty("p", controller::getP, controller::setP);
+		builder.addDoubleProperty("i", controller::getI, controller::setI);
+		builder.addDoubleProperty("d", controller::getD, controller::setD);
+	}
+}


### PR DESCRIPTION
The widget can be inserted to SmartDashboard like so: `SmartDashboard.putData(new SparkPIDWidget(mySparkPIDController));`
It can also be inserted into ShuffleboardTabs

Then you can tune PID easily with shuffleboard!