### PR TITLE
Add FF to SparkPIDWidget and fix bug with name

### DIFF
--- a/src/main/java/frc/team2412/robot/util/SparkPIDWidget.java
+++ b/src/main/java/frc/team2412/robot/util/SparkPIDWidget.java
@@ -9,10 +9,10 @@ public class SparkPIDWidget implements NTSendable {
 
 	public final SparkPIDController controller;
 
-	public SparkPIDWidget(SparkPIDController controller) {
+	public SparkPIDWidget(SparkPIDController controller, String name) {
 		this.controller = controller;
 
-		SendableRegistry.add(this, "Spark PID Controller");
+		SendableRegistry.add(this, name);
 	}
 
 	@Override
@@ -22,5 +22,6 @@ public class SparkPIDWidget implements NTSendable {
 		builder.addDoubleProperty("p", controller::getP, controller::setP);
 		builder.addDoubleProperty("i", controller::getI, controller::setI);
 		builder.addDoubleProperty("d", controller::getD, controller::setD);
+		builder.addDoubleProperty("ff", controller::getFF, controller::setFF);
 	}
 }


### PR DESCRIPTION
resolves #34

FF value getter/setter in Shuffleboard is not loaded automatically into the layout. It can be added by opening the NetworkTables table on the left and dragging the value over as an entry. This is a limitation with Shuffleboard itself and would need to be fixed with a plugin which would be pretty janky.