### PR TITLE
Add AprilTags robot localization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ tasks.withType(JavaCompile) {
 spotless {
 	format "misc", {
 		target "*"
-		targetExclude "simgui*.json", "**/build/**", "**/build-*/**", "**/bin/**", "/.*", "WPILib-License.md", "gradlew"
+		targetExclude "simgui*.json", "**/build/**", "**/build-*/**", "**/bin/**", "/.*", "WPILib-License.md", "gradlew", "networktables.json", "networktables.json.bck"
 		toggleOffOn()
 		indentWithTabs()
 		endWithNewline()
@@ -151,3 +151,7 @@ spotless {
 tasks.named("build") { finalizedBy("spotlessApply") }
 tasks.named("deploy") { finalizedBy("spotlessApply") }
 spotlessCheck.mustRunAfter(compileJava);
+
+javadoc {
+	options.links("https://github.wpilib.org/allwpilib/docs/release/java/")
+}

--- a/src/main/java/frc/team2412/robot/Hardware.java
+++ b/src/main/java/frc/team2412/robot/Hardware.java
@@ -1,7 +1,11 @@
 package frc.team2412.robot;
 
 public class Hardware {
-	// this is where we will ID the hardware, like motors n stuff
+	// apriltags stuff
+	public static final String PHOTON_CAM = "Arducam_OV9281_USB_Camera";
+	public static final String PHOTON_IP = "10.24.12.51";
+
+	// motor IDs:
 
 	// drive devices [1 - 19]
 

--- a/src/main/java/frc/team2412/robot/Hardware.java
+++ b/src/main/java/frc/team2412/robot/Hardware.java
@@ -3,7 +3,7 @@ package frc.team2412.robot;
 public class Hardware {
 	// apriltags stuff
 	public static final String PHOTON_CAM = "Arducam_OV9281_USB_Camera";
-	public static final String PHOTON_IP = "10.24.12.51";
+	public static final String PHOTON_IP = "10.24.12.12";
 
 	// motor IDs:
 

--- a/src/main/java/frc/team2412/robot/Robot.java
+++ b/src/main/java/frc/team2412/robot/Robot.java
@@ -69,7 +69,11 @@ public class Robot extends TimedRobot {
 		subsystems = new Subsystems();
 		controls = new Controls(subsystems);
 
-		autoChooser = AutoBuilder.buildAutoChooser();
+		if (Subsystems.SubsystemConstants.DRIVEBASE_ENABLED) {
+			autoChooser = AutoBuilder.buildAutoChooser();
+		} else {
+			autoChooser = new SendableChooser<>();
+		}
 
 		Shuffleboard.startRecording();
 

--- a/src/main/java/frc/team2412/robot/Subsystems.java
+++ b/src/main/java/frc/team2412/robot/Subsystems.java
@@ -2,9 +2,11 @@ package frc.team2412.robot;
 
 import static frc.team2412.robot.Subsystems.SubsystemConstants.*;
 
+import frc.team2412.robot.sensors.AprilTagsProcessor;
 import frc.team2412.robot.subsystems.DrivebaseSubsystem;
 import frc.team2412.robot.subsystems.IntakeSubsystem;
 import frc.team2412.robot.subsystems.LauncherSubsystem;
+import frc.team2412.robot.util.DrivebaseWrapper;
 
 public class Subsystems {
 	public static class SubsystemConstants {
@@ -19,14 +21,25 @@ public class Subsystems {
 		public static final boolean DRIVEBASE_ENABLED = true;
 	}
 
+	public final DrivebaseWrapper drivebaseWrapper;
 	public final DrivebaseSubsystem drivebaseSubsystem;
 	public final LauncherSubsystem launcherSubsystem;
 	public final IntakeSubsystem intakeSubsystem;
+	public final AprilTagsProcessor apriltagsProcessor;
 
 	public Subsystems() {
 		// initialize subsystems here (wow thats wild)
 		if (DRIVEBASE_ENABLED) {
 			drivebaseSubsystem = new DrivebaseSubsystem();
+			drivebaseWrapper = new DrivebaseWrapper(drivebaseSubsystem.getSwerveDrive());
+		} else {
+			drivebaseSubsystem = null;
+			drivebaseWrapper = new DrivebaseWrapper();
+		}
+		if (APRILTAGS_ENABLED) {
+			apriltagsProcessor = new AprilTagsProcessor(drivebaseWrapper);
+		} else {
+			apriltagsProcessor = null;
 		}
 		if (LAUNCHER_ENABLED) {
 			launcherSubsystem = new LauncherSubsystem();

--- a/src/main/java/frc/team2412/robot/sensors/AprilTagsProcessor.java
+++ b/src/main/java/frc/team2412/robot/sensors/AprilTagsProcessor.java
@@ -1,0 +1,150 @@
+package frc.team2412.robot.sensors;
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
+import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.Vector;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.networktables.NetworkTableEvent;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import edu.wpi.first.wpilibj.smartdashboard.FieldObject2d;
+import frc.team2412.robot.Hardware;
+import frc.team2412.robot.Robot;
+import frc.team2412.robot.util.DrivebaseWrapper;
+import frc.team2412.robot.util.SendablePose3d;
+import java.util.EnumSet;
+import java.util.Optional;
+import org.photonvision.EstimatedRobotPose;
+import org.photonvision.PhotonCamera;
+import org.photonvision.PhotonPoseEstimator;
+import org.photonvision.PhotonPoseEstimator.PoseStrategy;
+import org.photonvision.targeting.PhotonPipelineResult;
+
+/**
+ * All 3D poses and transforms use the NWU (North-West-Up) coordinate system, where +X is
+ * north/forward, +Y is west/left, and +Z is up. On the field, this is based on the blue driver
+ * station. (+X is forward from blue driver station, +Y is left, and +Z is up. Additionally, the
+ * origin is the right corner of the blue driver station- All coordinates should be non-negative.)
+ *
+ * <p>Rotations follow the right-hand rule- If the thumb of a right hand is pointed in a positive
+ * axis, the fingers curl in the direction of positive rotation. Alternatively, the rotation is CCW+
+ * looking into the positive axis.
+ *
+ * <p>2D field poses are just the projection of the 3D pose onto the XY plane.
+ */
+public class AprilTagsProcessor {
+	public static final Transform3d ROBOT_TO_CAM =
+			new Transform3d(
+					Units.inchesToMeters(27.0 / 2.0 - 0.94996),
+					0,
+					Units.inchesToMeters(8.12331),
+					new Rotation3d(0, Units.degreesToRadians(-30), 0));
+
+	// TODO Measure these
+	private static final Vector<N3> STANDARD_DEVS =
+			VecBuilder.fill(0.1, 0.1, Units.degreesToRadians(5));
+
+	private final PhotonCamera photonCamera;
+	private final PhotonPoseEstimator photonPoseEstimator;
+	private final DrivebaseWrapper aprilTagsHelper;
+	private final FieldObject2d rawVisionFieldObject;
+
+	// These are always set with every pipeline result
+	private PhotonPipelineResult latestResult = null;
+	private Optional<EstimatedRobotPose> latestPose = Optional.empty();
+
+	// These are only set when there's a valid pose
+	private double lastTimestampSeconds = 0;
+	private Pose2d lastFieldPose = new Pose2d(-1, -1, new Rotation2d());
+
+	private static final AprilTagFieldLayout fieldLayout =
+			AprilTagFields.k2024Crescendo.loadAprilTagLayoutField();
+
+	public AprilTagsProcessor(DrivebaseWrapper aprilTagsHelper) {
+		this.aprilTagsHelper = aprilTagsHelper;
+		rawVisionFieldObject = aprilTagsHelper.getField().getObject("RawVision");
+		var networkTables = NetworkTableInstance.getDefault();
+		if (Robot.isSimulation()) {
+			networkTables.stopServer();
+			networkTables.setServer(Hardware.PHOTON_IP);
+			networkTables.startClient4("Photonvision");
+		}
+
+		photonCamera = new PhotonCamera(Hardware.PHOTON_CAM);
+		photonPoseEstimator =
+				new PhotonPoseEstimator(
+						fieldLayout, PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR, photonCamera, ROBOT_TO_CAM);
+
+		networkTables.addListener(
+				networkTables
+						.getTable("photonvision")
+						.getSubTable(Hardware.PHOTON_CAM)
+						.getEntry("rawBytes"),
+				EnumSet.of(NetworkTableEvent.Kind.kValueAll),
+				event -> update());
+
+		ShuffleboardTab shuffleboardTab = Shuffleboard.getTab("AprilTags");
+		shuffleboardTab.addBoolean("Has targets", this::hasTargets).withPosition(0, 0).withSize(1, 1);
+		shuffleboardTab
+				.addInteger("Num targets", this::getNumTargets)
+				.withPosition(0, 1)
+				.withSize(1, 1);
+		shuffleboardTab
+				.addDouble("Last timestamp", this::getLastTimestampSeconds)
+				.withPosition(1, 0)
+				.withSize(1, 1);
+		shuffleboardTab
+				.add("3d pose on field", new SendablePose3d(this::getRobotPose))
+				.withPosition(2, 0)
+				.withSize(1, 6);
+	}
+
+	public void update() {
+		latestResult = photonCamera.getLatestResult();
+		latestPose = photonPoseEstimator.update(latestResult);
+		if (latestPose.isPresent()) {
+			lastTimestampSeconds = latestPose.get().timestampSeconds;
+			lastFieldPose = latestPose.get().estimatedPose.toPose2d();
+			rawVisionFieldObject.setPose(lastFieldPose);
+			aprilTagsHelper.addVisionMeasurement(lastFieldPose, lastTimestampSeconds, STANDARD_DEVS);
+			aprilTagsHelper.getField().setRobotPose(aprilTagsHelper.getEstimatedPosition());
+		}
+	}
+
+	public boolean hasTargets() {
+		return latestPose.isPresent();
+	}
+
+	public int getNumTargets() {
+		return latestResult == null ? -1 : latestResult.getTargets().size();
+	}
+
+	/**
+	 * Calculates the robot pose using the best target. Returns null if there is no known robot pose.
+	 *
+	 * @return The calculated robot pose in meters.
+	 */
+	public Pose3d getRobotPose() {
+		if (latestPose.isPresent()) {
+			return latestPose.get().estimatedPose;
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the last time we saw an AprilTag.
+	 *
+	 * @return The time we last saw an AprilTag in seconds since FPGA startup.
+	 */
+	public double getLastTimestampSeconds() {
+		return lastTimestampSeconds;
+	}
+}

--- a/src/main/java/frc/team2412/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/DrivebaseSubsystem.java
@@ -294,4 +294,9 @@ public class DrivebaseSubsystem extends SubsystemBase {
 						.getEntry();
 		xWheelsEnabled = xWheelsEntry.getBoolean(true);
 	}
+
+	/** Get the YAGSL {@link SwerveDrive} object. */
+	public SwerveDrive getSwerveDrive() {
+		return swerveDrive;
+	}
 }

--- a/src/main/java/frc/team2412/robot/util/DrivebaseWrapper.java
+++ b/src/main/java/frc/team2412/robot/util/DrivebaseWrapper.java
@@ -1,0 +1,99 @@
+package frc.team2412.robot.util;
+
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.math.kinematics.SwerveModulePosition;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.wpilibj.smartdashboard.Field2d;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import swervelib.SwerveDrive;
+
+/**
+ * Wrapper class around members of {@link SwerveDrive}, like the Field2d telemetry and the pose
+ * estimator.
+ */
+public class DrivebaseWrapper {
+	@FunctionalInterface
+	private static interface VisionMeasurementAdder {
+		void addVisionMeasurement(Pose2d robotPose, double timestamp, Matrix<N3, N1> stdDevs);
+	}
+
+	private final Field2d field;
+
+	// Use the pose estimator ONLY for thread-safe operations!
+	private final SwerveDrivePoseEstimator poseEstimator;
+
+	// Since adding a vision measurement is not thread-safe, use a functional interface that can use
+	// SwerveDrive's methods (which are thread-safe)
+	private final VisionMeasurementAdder visionMeasurementAdder;
+
+	/** Constructor for when there is no drivebase. */
+	public DrivebaseWrapper() {
+		field = new Field2d();
+		// YAGSL will normally do this for us
+		// This may be pointless though since Field2d can't be shown in both SmartDashboard and the
+		// MatchDashboard tab
+		SmartDashboard.putData("Field", field);
+		// Because there's no drivebase attached, we aren't using odometry and so module locations etc.
+		// don't matter (but kinematics requires at least 2 module positions)
+		var dummyModulePositions =
+				new SwerveModulePosition[] {new SwerveModulePosition(), new SwerveModulePosition()};
+		poseEstimator =
+				new SwerveDrivePoseEstimator(
+						new SwerveDriveKinematics(new Translation2d(1, 1), new Translation2d(-1, -1)),
+						new Rotation2d(),
+						dummyModulePositions,
+						new Pose2d());
+		visionMeasurementAdder = poseEstimator::addVisionMeasurement;
+		// The pose estimator will silently ignore updates if the internal pose buffer is empty, so add
+		// an odometry measurement to get started
+		poseEstimator.updateWithTime(0, new Rotation2d(), dummyModulePositions);
+	}
+
+	/**
+	 * Constructor for when there is a drivebase.
+	 *
+	 * @param swerveDrive The drivebase object to use.
+	 */
+	public DrivebaseWrapper(SwerveDrive swerveDrive) {
+		field = swerveDrive.field;
+		poseEstimator = swerveDrive.swerveDrivePoseEstimator;
+		visionMeasurementAdder = swerveDrive::addVisionMeasurement;
+	}
+
+	/**
+	 * The {@link Field2d} object to use for telemetry.
+	 *
+	 * @return The Field2d object.
+	 */
+	public Field2d getField() {
+		return field;
+	}
+
+	/**
+	 * Adds a vision measurement with the specified standard deviations.
+	 *
+	 * @param robotPose Pose of the robot on the field in meters.
+	 * @param timestamp Timestamp of the vision measurement in seconds since FPGA startup.
+	 * @param stdDevs The standard deviations of the vision measurement. (X position in meters, Y
+	 *     position in meters, and heading in radians)
+	 * @see SwerveDrivePoseEstimator#addVisionMeasurement(Pose2d, double, Matrix)
+	 */
+	public void addVisionMeasurement(Pose2d robotPose, double timestamp, Matrix<N3, N1> stdDevs) {
+		visionMeasurementAdder.addVisionMeasurement(robotPose, timestamp, stdDevs);
+	}
+
+	/**
+	 * Return the pose estimator's estimate of the robot position.
+	 *
+	 * @return The estimated pose.
+	 */
+	public Pose2d getEstimatedPosition() {
+		return poseEstimator.getEstimatedPosition();
+	}
+}

--- a/src/main/java/frc/team2412/robot/util/MatchDashboard.java
+++ b/src/main/java/frc/team2412/robot/util/MatchDashboard.java
@@ -15,7 +15,7 @@ public class MatchDashboard {
 	private final Field2d field;
 
 	public MatchDashboard(Subsystems s) {
-		field = s.drivebaseSubsystem.getField();
+		field = s.drivebaseWrapper.getField();
 
 		tab.add(new FMSWidget()).withPosition(0, 0).withSize(4, 1);
 		tab.add(field).withPosition(0, 1).withSize(4, 3);

--- a/src/main/java/frc/team2412/robot/util/SendablePose3d.java
+++ b/src/main/java/frc/team2412/robot/util/SendablePose3d.java
@@ -1,0 +1,41 @@
+package frc.team2412.robot.util;
+
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import java.util.function.Supplier;
+
+public class SendablePose3d implements Sendable {
+	private static final Pose3d defaultPose = new Pose3d(-1, -1, -1, new Rotation3d());
+	private Supplier<Pose3d> poseSupplier;
+
+	public SendablePose3d(Supplier<Pose3d> poseSupplier) {
+		this.poseSupplier = poseSupplier;
+	}
+
+	public SendablePose3d(Pose3d pose) {
+		this(() -> pose);
+	}
+
+	private Pose3d getPose() {
+		Pose3d pose = poseSupplier.get();
+		if (pose == null) {
+			return defaultPose;
+		}
+		return pose;
+	}
+
+	@Override
+	public void initSendable(SendableBuilder builder) {
+		builder.addDoubleProperty("Translation X", () -> getPose().getX(), null);
+		builder.addDoubleProperty("Translation Y", () -> getPose().getY(), null);
+		builder.addDoubleProperty("Translation Z", () -> getPose().getZ(), null);
+		builder.addDoubleProperty(
+				"Angle X (deg)", () -> Math.toDegrees(getPose().getRotation().getX()), null);
+		builder.addDoubleProperty(
+				"Angle Y (deg)", () -> Math.toDegrees(getPose().getRotation().getY()), null);
+		builder.addDoubleProperty(
+				"Angle Z (deg)", () -> Math.toDegrees(getPose().getRotation().getZ()), null);
+	}
+}

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,0 +1,57 @@
+{
+    "fileName": "photonlib.json",
+    "name": "photonlib",
+    "version": "v2024.2.4",
+    "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
+    "frcYear": "2024",
+    "mavenUrls": [
+        "https://maven.photonvision.org/repository/internal",
+        "https://maven.photonvision.org/repository/snapshots"
+    ],
+    "jsonUrl": "https://maven.photonvision.org/repository/internal/org/photonvision/photonlib-json/1.0/photonlib-json-1.0.json",
+    "jniDependencies": [],
+    "cppDependencies": [
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "photonlib-cpp",
+            "version": "v2024.2.4",
+            "libName": "photonlib",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxathena",
+                "linuxx86-64",
+                "osxuniversal"
+            ]
+        },
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "photontargeting-cpp",
+            "version": "v2024.2.4",
+            "libName": "photontargeting",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxathena",
+                "linuxx86-64",
+                "osxuniversal"
+            ]
+        }
+    ],
+    "javaDependencies": [
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "photonlib-java",
+            "version": "v2024.2.4"
+        },
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "photontargeting-java",
+            "version": "v2024.2.4"
+        }
+    ]
+}


### PR DESCRIPTION
Some other miscellaneous changes:
* Make stuff work without drivebase enabled (so that I could test robot localization without drivebase, though I'm still not sure about the exact cases we want to handle)
* Prevent spotless from processing networktables.json and networktables.json.bck
* Let the generated Javadocs reference the wpilib docs (I looked at them once to check an `@see` specification)
* Add SendablePose3d to help with the dashboard display (though I haven't actually ran Shuffleboard with the robot code yet)