### PR TITLE
Enable FOC control for drivebase

### DIFF
--- a/src/main/java/swervelib/motors/TalonFXSwerve.java
+++ b/src/main/java/swervelib/motors/TalonFXSwerve.java
@@ -42,6 +42,11 @@ public class TalonFXSwerve extends SwerveMotor {
 		factoryDefaults();
 		clearStickyFaults();
 
+		if (motor.getIsProLicensed().getValue()) {
+			m_angleVoltageSetter.EnableFOC = true;
+			m_velocityVoltageSetter.EnableFOC = true;
+		}
+
 		//    if (SwerveDriveTelemetry.isSimulation)
 		//    {
 		////      PhysicsSim.getInstance().addTalonFX(motor, .25, 6800);


### PR DESCRIPTION
Need to actually license the motors before we can use this. We bought the season pass earlier this year so we can license up to 60 devices including 2 CANivores which can license their connected motors. I'll probably try and license Bonk, the practice bot, and the comp bot.

Might make sense to add an easier way to disable FOC in code in the future.