### PR TITLE
Vision improvements

### DIFF
--- a/src/main/java/frc/team2412/robot/sensors/AprilTagsProcessor.java
+++ b/src/main/java/frc/team2412/robot/sensors/AprilTagsProcessor.java
@@ -65,7 +65,8 @@ public class AprilTagsProcessor {
 	private static final double ROBOT_TO_TARGET_PITCH_TOLERANCE = 0.1;
 
 	private static boolean hasCorrectPitch(Transform3d camToTarget) {
-		return Math.abs(ROBOT_TO_CAM.getRotation().plus(camToTarget.getRotation()).getY())
+		// Intrinsic robot to cam + cam to target = extrinsic cam to target + robot to cam
+		return Math.abs(camToTarget.getRotation().plus(ROBOT_TO_CAM.getRotation()).getY())
 				< ROBOT_TO_TARGET_PITCH_TOLERANCE;
 	}
 

--- a/src/main/java/frc/team2412/robot/sensors/AprilTagsProcessor.java
+++ b/src/main/java/frc/team2412/robot/sensors/AprilTagsProcessor.java
@@ -46,7 +46,7 @@ public class AprilTagsProcessor {
 					Units.inchesToMeters(27.0 / 2.0 - 0.94996),
 					0,
 					Units.inchesToMeters(8.12331),
-					new Rotation3d(0, Units.degreesToRadians(-30), 0));
+					new Rotation3d(Units.degreesToRadians(90), Units.degreesToRadians(-30), 0));
 
 	// TODO Measure these
 	private static final Vector<N3> STANDARD_DEVS = VecBuilder.fill(1, 1, Units.degreesToRadians(30));

--- a/src/main/java/frc/team2412/robot/sensors/AprilTagsProcessor.java
+++ b/src/main/java/frc/team2412/robot/sensors/AprilTagsProcessor.java
@@ -61,15 +61,12 @@ public class AprilTagsProcessor {
 
 	private static final double MAX_POSE_AMBIGUITY = 0.1;
 
-	// Both of these are in radians
-	// Negate to convert robot to cam to cam to robot, and negate again because tag is flipped,
-	// leading to no net effect
-	private static final double EXPECTED_CAM_TO_TARGET_PITCH = ROBOT_TO_CAM.getRotation().getY();
-	private static final double CAM_TO_TARGET_PITCH_TOLERANCE = 0.1;
+	// Radians
+	private static final double ROBOT_TO_TARGET_PITCH_TOLERANCE = 0.1;
 
 	private static boolean hasCorrectPitch(Transform3d camToTarget) {
-		return Math.abs(camToTarget.getRotation().getY() - EXPECTED_CAM_TO_TARGET_PITCH)
-				< CAM_TO_TARGET_PITCH_TOLERANCE;
+		return Math.abs(ROBOT_TO_CAM.getRotation().plus(camToTarget.getRotation()).getY())
+				< ROBOT_TO_TARGET_PITCH_TOLERANCE;
 	}
 
 	private static PhotonTrackedTarget swapBestAndAltTransforms(PhotonTrackedTarget target) {

--- a/src/main/java/frc/team2412/robot/sensors/AprilTagsProcessor.java
+++ b/src/main/java/frc/team2412/robot/sensors/AprilTagsProcessor.java
@@ -62,12 +62,14 @@ public class AprilTagsProcessor {
 	private static final double MAX_POSE_AMBIGUITY = 0.1;
 
 	// Radians
+	private static final double ROBOT_TO_TARGET_ROLL_TOLERANCE = 0.1;
 	private static final double ROBOT_TO_TARGET_PITCH_TOLERANCE = 0.1;
 
-	private static boolean hasCorrectPitch(Transform3d camToTarget) {
+	private static boolean hasValidRotation(Transform3d camToTarget) {
 		// Intrinsic robot to cam + cam to target = extrinsic cam to target + robot to cam
-		return Math.abs(camToTarget.getRotation().plus(ROBOT_TO_CAM.getRotation()).getY())
-				< ROBOT_TO_TARGET_PITCH_TOLERANCE;
+		var robotToTargetRotation = camToTarget.getRotation().plus(ROBOT_TO_CAM.getRotation());
+		return (Math.abs(robotToTargetRotation.getX()) < ROBOT_TO_TARGET_ROLL_TOLERANCE)
+				&& (Math.abs(robotToTargetRotation.getY()) < ROBOT_TO_TARGET_PITCH_TOLERANCE);
 	}
 
 	private static PhotonTrackedTarget swapBestAndAltTransforms(PhotonTrackedTarget target) {
@@ -92,8 +94,8 @@ public class AprilTagsProcessor {
 				copy.targets.remove(i);
 				continue;
 			}
-			if (!hasCorrectPitch(target.getBestCameraToTarget())) {
-				if (hasCorrectPitch(target.getAlternateCameraToTarget())) {
+			if (!hasValidRotation(target.getBestCameraToTarget())) {
+				if (hasValidRotation(target.getAlternateCameraToTarget())) {
 					target = swapBestAndAltTransforms(target);
 					copy.targets.set(i, target);
 				} else {

--- a/src/main/java/frc/team2412/robot/sensors/AprilTagsProcessor.java
+++ b/src/main/java/frc/team2412/robot/sensors/AprilTagsProcessor.java
@@ -90,15 +90,15 @@ public class AprilTagsProcessor {
 		var copy = copy(result);
 		for (int i = copy.targets.size() - 1; i >= 0; --i) {
 			var target = copy.targets.get(i);
+			if (target.getPoseAmbiguity() > MAX_POSE_AMBIGUITY) {
+				copy.targets.remove(i);
+				continue;
+			}
 			if (!hasCorrectPitch(target.getBestCameraToTarget())) {
 				if (hasCorrectPitch(target.getAlternateCameraToTarget())) {
 					target = swapBestAndAltTransforms(target);
 					copy.targets.set(i, target);
 				} else {
-					copy.targets.remove(i);
-					continue;
-				}
-				if (target.getPoseAmbiguity() > MAX_POSE_AMBIGUITY) {
 					copy.targets.remove(i);
 					continue;
 				}

--- a/src/main/java/frc/team2412/robot/sensors/AprilTagsProcessor.java
+++ b/src/main/java/frc/team2412/robot/sensors/AprilTagsProcessor.java
@@ -13,7 +13,6 @@ import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.networktables.NetworkTableEvent;
 import edu.wpi.first.networktables.NetworkTableInstance;
-import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.FieldObject2d;
@@ -68,10 +67,6 @@ public class AprilTagsProcessor {
 	private static final double EXPECTED_CAM_TO_TARGET_PITCH = ROBOT_TO_CAM.getRotation().getY();
 	private static final double CAM_TO_TARGET_PITCH_TOLERANCE = 0.1;
 
-	static {
-		System.out.println("Expected pitch: " + EXPECTED_CAM_TO_TARGET_PITCH);
-	}
-
 	private static boolean hasCorrectPitch(Transform3d camToTarget) {
 		return Math.abs(camToTarget.getRotation().getY() - EXPECTED_CAM_TO_TARGET_PITCH)
 				< CAM_TO_TARGET_PITCH_TOLERANCE;
@@ -99,36 +94,12 @@ public class AprilTagsProcessor {
 				if (hasCorrectPitch(target.getAlternateCameraToTarget())) {
 					target = swapBestAndAltTransforms(target);
 					copy.targets.set(i, target);
-					if (canPrint) {
-						System.out.println(
-								"Swapped best and alt transform for target "
-										+ i
-										+ " (best pitch="
-										+ target.getBestCameraToTarget().getRotation().getY()
-										+ ", alt pitch="
-										+ target.getAlternateCameraToTarget().getRotation().getY()
-										+ ")");
-					}
 				} else {
 					copy.targets.remove(i);
-					if (canPrint) {
-						System.out.println(
-								"Removed target "
-										+ i
-										+ " (best pitch="
-										+ target.getBestCameraToTarget().getRotation().getY()
-										+ ", alt pitch="
-										+ target.getAlternateCameraToTarget().getRotation().getY()
-										+ ") because of bad pitch ");
-					}
 					continue;
 				}
 				if (target.getPoseAmbiguity() > MAX_POSE_AMBIGUITY) {
 					copy.targets.remove(i);
-					if (canPrint) {
-						System.out.println(
-								"Excluded target " + i + " with ambiguity " + target.getPoseAmbiguity());
-					}
 					continue;
 				}
 			}
@@ -149,9 +120,6 @@ public class AprilTagsProcessor {
 	// These are only set when there's a valid pose
 	private double lastTimestampSeconds = 0;
 	private Pose2d lastFieldPose = new Pose2d(-1, -1, new Rotation2d());
-
-	private static double lastPrintTimeSeconds = -1;
-	private static boolean canPrint = false;
 
 	private static final AprilTagFieldLayout fieldLayout =
 			AprilTagFields.k2024Crescendo.loadAprilTagLayoutField();
@@ -199,19 +167,10 @@ public class AprilTagsProcessor {
 	}
 
 	public void update() {
-		double now = Timer.getFPGATimestamp();
-		canPrint = now - lastPrintTimeSeconds >= 1;
-		if (canPrint) {
-			lastPrintTimeSeconds = now;
-			System.out.println("Got update at " + now);
-		}
 		latestResult = photonCamera.getLatestResult();
 		latestFilteredResult = filteredPipelineResult(latestResult);
 		latestPose = photonPoseEstimator.update(latestFilteredResult);
 		if (latestPose.isPresent()) {
-			if (canPrint) {
-				System.out.println("Have result");
-			}
 			lastTimestampSeconds = latestPose.get().timestampSeconds;
 			lastFieldPose = latestPose.get().estimatedPose.toPose2d();
 			rawVisionFieldObject.setPose(lastFieldPose);

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "photonlib.json",
     "name": "photonlib",
-    "version": "v2024.2.4",
+    "version": "v2024.2.9",
     "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
     "frcYear": "2024",
     "mavenUrls": [
@@ -14,7 +14,7 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photonlib-cpp",
-            "version": "v2024.2.4",
+            "version": "v2024.2.9",
             "libName": "photonlib",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -29,7 +29,7 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photontargeting-cpp",
-            "version": "v2024.2.4",
+            "version": "v2024.2.9",
             "libName": "photontargeting",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -46,12 +46,12 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photonlib-java",
-            "version": "v2024.2.4"
+            "version": "v2024.2.9"
         },
         {
             "groupId": "org.photonvision",
             "artifactId": "photontargeting-java",
-            "version": "v2024.2.4"
+            "version": "v2024.2.9"
         }
     ]
 }


### PR DESCRIPTION
Changes:
* Update to PhotonVision 2024.2.9 (This was done to the Orange Pi as well)
* Incorporate rotation into `ROBOT_TO_CAM` instead of rotating the camera stream (Rotating the camera stream messed with calibration)
* Fix pitch check and make it check roll as well
* Separate raw and filtered results and improve look of pose display

Notes:
* 31a7fa0 was tested on Crane but not on Toucan as of 3/18
* We may need to change the roll later depending on how we mount the camera on Toucan