### PR TITLE
Rotate to apriltag

### DIFF
--- a/src/main/java/frc/team2412/robot/Controls.java
+++ b/src/main/java/frc/team2412/robot/Controls.java
@@ -11,8 +11,8 @@ import static frc.team2412.robot.Subsystems.SubsystemConstants.LED_ENABLED;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.GenericHID.RumbleType;
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
@@ -30,7 +30,6 @@ import frc.team2412.robot.commands.launcher.ManualAngleCommand;
 import frc.team2412.robot.commands.launcher.SetAngleAmpLaunchCommand;
 import frc.team2412.robot.commands.launcher.SetAngleLaunchCommand;
 import frc.team2412.robot.commands.launcher.SetPivotCommand;
-import frc.team2412.robot.sensors.AprilTagsProcessor;
 import frc.team2412.robot.subsystems.LauncherSubsystem;
 import frc.team2412.robot.util.AmpAlign;
 
@@ -145,15 +144,15 @@ public class Controls {
 							s.drivebaseSubsystem
 									.rotateToAngle(
 											() -> {
-												var speakerPose =
-														DriverStation.getAlliance().orElse(Alliance.Red) == Alliance.Red
-																? AprilTagsProcessor.RED_SPEAKER_POSE
-																: AprilTagsProcessor.BLUE_SPEAKER_POSE;
-												var robotToSpeaker =
-														speakerPose
-																.getTranslation()
-																.minus(s.drivebaseSubsystem.getPose().getTranslation());
-												return robotToSpeaker.getAngle();
+												double currentTimestamp = Timer.getFPGATimestamp();
+												double robotToTagAngleTimestamp =
+														s.apriltagsProcessor.getLastRotatedAngleTimestamp();
+												var robotAngle = s.drivebaseSubsystem.getPose().getRotation();
+												var robotToTagAngle = s.apriltagsProcessor.getLastRotatedAngle();
+												if (currentTimestamp - robotToTagAngleTimestamp > 0.1) {
+													return robotAngle;
+												}
+												return robotAngle.plus(robotToTagAngle);
 											},
 											false)
 									.withName("RotateToSpeaker"));

--- a/src/main/java/frc/team2412/robot/Controls.java
+++ b/src/main/java/frc/team2412/robot/Controls.java
@@ -265,7 +265,7 @@ public class Controls {
 		// 				s.launcherSubsystem.runEnd(
 		// 						s.launcherSubsystem::launch, s.launcherSubsystem::stopLauncher));
 
-		driveController.b().onTrue(new InstantCommand(() -> s.launcherSubsystem.launch(6500)));
+		driveController.b().onTrue(new InstantCommand(() -> s.launcherSubsystem.launch()));
 	}
 
 	private void bindSysIdControls() {

--- a/src/main/java/frc/team2412/robot/Controls.java
+++ b/src/main/java/frc/team2412/robot/Controls.java
@@ -2,6 +2,7 @@ package frc.team2412.robot;
 
 import static frc.team2412.robot.Controls.ControlConstants.CODRIVER_CONTROLLER_PORT;
 import static frc.team2412.robot.Controls.ControlConstants.CONTROLLER_PORT;
+import static frc.team2412.robot.Subsystems.SubsystemConstants.APRILTAGS_ENABLED;
 import static frc.team2412.robot.Subsystems.SubsystemConstants.DRIVEBASE_ENABLED;
 import static frc.team2412.robot.Subsystems.SubsystemConstants.INTAKE_ENABLED;
 import static frc.team2412.robot.Subsystems.SubsystemConstants.LAUNCHER_ENABLED;
@@ -10,6 +11,7 @@ import static frc.team2412.robot.Subsystems.SubsystemConstants.LED_ENABLED;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.GenericHID.RumbleType;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Commands;
@@ -28,6 +30,7 @@ import frc.team2412.robot.commands.launcher.ManualAngleCommand;
 import frc.team2412.robot.commands.launcher.SetAngleAmpLaunchCommand;
 import frc.team2412.robot.commands.launcher.SetAngleLaunchCommand;
 import frc.team2412.robot.commands.launcher.SetPivotCommand;
+import frc.team2412.robot.sensors.AprilTagsProcessor;
 import frc.team2412.robot.subsystems.LauncherSubsystem;
 import frc.team2412.robot.util.AmpAlign;
 
@@ -135,6 +138,25 @@ public class Controls {
 			// 						s.drivebaseSubsystem,
 			// 						this,
 			// 						codriveController.leftBumper()));
+		}
+		if (DRIVEBASE_ENABLED && APRILTAGS_ENABLED) {
+			new Trigger(s.rotateToSpeaker)
+					.whileTrue(
+							s.drivebaseSubsystem
+									.rotateToAngle(
+											() -> {
+												var speakerPose =
+														DriverStation.getAlliance().orElse(Alliance.Red) == Alliance.Red
+																? AprilTagsProcessor.RED_SPEAKER_POSE
+																: AprilTagsProcessor.BLUE_SPEAKER_POSE;
+												var robotToSpeaker =
+														speakerPose
+																.getTranslation()
+																.minus(s.drivebaseSubsystem.getPose().getTranslation());
+												return robotToSpeaker.getAngle();
+											},
+											false)
+									.withName("RotateToSpeaker"));
 		}
 	}
 	// LED

--- a/src/main/java/frc/team2412/robot/Subsystems.java
+++ b/src/main/java/frc/team2412/robot/Subsystems.java
@@ -9,6 +9,7 @@ import frc.team2412.robot.subsystems.LEDSubsystem;
 import frc.team2412.robot.subsystems.LauncherSubsystem;
 import frc.team2412.robot.subsystems.LimelightSubsystem;
 import frc.team2412.robot.util.DrivebaseWrapper;
+import java.util.function.BooleanSupplier;
 
 public class Subsystems {
 	public static class SubsystemConstants {
@@ -29,6 +30,7 @@ public class Subsystems {
 	public final IntakeSubsystem intakeSubsystem;
 	public final LEDSubsystem ledSubsystem;
 	public final AprilTagsProcessor apriltagsProcessor;
+	public final BooleanSupplier rotateToSpeaker;
 
 	public Subsystems() {
 		// initialize subsystems here (wow thats wild)
@@ -41,8 +43,10 @@ public class Subsystems {
 		}
 		if (APRILTAGS_ENABLED) {
 			apriltagsProcessor = new AprilTagsProcessor(drivebaseWrapper);
+			rotateToSpeaker = () -> apriltagsProcessor.shouldRotateToSpeaker();
 		} else {
 			apriltagsProcessor = null;
+			rotateToSpeaker = () -> false;
 		}
 		if (LAUNCHER_ENABLED) {
 			launcherSubsystem = new LauncherSubsystem();

--- a/src/main/java/frc/team2412/robot/sensors/AprilTagsProcessor.java
+++ b/src/main/java/frc/team2412/robot/sensors/AprilTagsProcessor.java
@@ -11,8 +11,10 @@ import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.util.Units;
+import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.networktables.NetworkTableEvent;
 import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.FieldObject2d;
@@ -81,6 +83,8 @@ public class AprilTagsProcessor {
 	private final DrivebaseWrapper aprilTagsHelper;
 	private final FieldObject2d rawVisionFieldObject;
 
+	private final GenericEntry rotateToSpeakerEntry;
+
 	// These are always set with every pipeline result
 	private double lastRawTimestampSeconds = 0;
 	private PhotonPipelineResult latestResult = null;
@@ -95,6 +99,9 @@ public class AprilTagsProcessor {
 
 	private static final AprilTagFieldLayout fieldLayout =
 			AprilTagFields.k2024Crescendo.loadAprilTagLayoutField();
+
+	public static final Pose2d RED_SPEAKER_POSE = fieldLayout.getTagPose(4).get().toPose2d();
+	public static final Pose2d BLUE_SPEAKER_POSE = fieldLayout.getTagPose(7).get().toPose2d();
 
 	public AprilTagsProcessor(DrivebaseWrapper aprilTagsHelper) {
 		this.aprilTagsHelper = aprilTagsHelper;
@@ -143,6 +150,13 @@ public class AprilTagsProcessor {
 				.add("3d pose on field", new SendablePose3d(this::getRobotPose))
 				.withPosition(2, 0)
 				.withSize(2, 2);
+		rotateToSpeakerEntry =
+				shuffleboardTab
+						.add("Rotate to speaker tag", false)
+						.withPosition(0, 2)
+						.withSize(1, 1)
+						.withWidget(BuiltInWidgets.kToggleSwitch)
+						.getEntry();
 	}
 
 	public void update() {
@@ -162,6 +176,15 @@ public class AprilTagsProcessor {
 			aprilTagsHelper.getField().setRobotPose(estimatedPose);
 			photonPoseEstimator.setLastPose(estimatedPose);
 		}
+	}
+
+	/**
+	 * Indicates if the rotate to speaker toggle is selected.
+	 *
+	 * @return Whether the rotate to speaker toggle is selected.
+	 */
+	public boolean shouldRotateToSpeaker() {
+		return rotateToSpeakerEntry.getBoolean(false);
 	}
 
 	/**

--- a/src/main/java/frc/team2412/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/DrivebaseSubsystem.java
@@ -196,32 +196,34 @@ public class DrivebaseSubsystem extends SubsystemBase {
 			Supplier<Rotation2d> rotation,
 			BooleanSupplier turboRotation) {
 		return this.run(
-				() -> {
-					Rotation2d constrainedRotation =
-							Rotation2d.fromRotations(
-									SwerveMath.applyDeadband(rotation.get().getRotations(), true, JOYSTICK_DEADBAND)
-											* MAX_SPEED
-											* (turboRotation.getAsBoolean()
-													? turboRotationMultiplierEntry.getDouble(1.0)
-													: 1)
-											* rotationSpeedEntry.getDouble(1.0)
-											* -1);
-					Translation2d constrainedTranslation =
-							new Translation2d(
-									SwerveMath.applyDeadband(forward.getAsDouble(), true, JOYSTICK_DEADBAND)
-											* MAX_SPEED
-											* translationSpeedEntry.getDouble(1.0),
-									SwerveMath.applyDeadband(strafe.getAsDouble(), true, JOYSTICK_DEADBAND)
-											* MAX_SPEED
-											* translationSpeedEntry.getDouble(1.0));
-					if (DriverStation.getAlliance().orElse(Alliance.Blue) == Alliance.Red) {
-						constrainedTranslation = constrainedTranslation.unaryMinus();
-					}
-					if (flipTranslationEntry.getBoolean(false)) {
-						constrainedTranslation = constrainedTranslation.unaryMinus();
-					}
-					drive(constrainedTranslation, constrainedRotation, true);
-				});
+						() -> {
+							Rotation2d constrainedRotation =
+									Rotation2d.fromRotations(
+											SwerveMath.applyDeadband(
+															rotation.get().getRotations(), true, JOYSTICK_DEADBAND)
+													* MAX_SPEED
+													* (turboRotation.getAsBoolean()
+															? turboRotationMultiplierEntry.getDouble(1.0)
+															: 1)
+													* rotationSpeedEntry.getDouble(1.0)
+													* -1);
+							Translation2d constrainedTranslation =
+									new Translation2d(
+											SwerveMath.applyDeadband(forward.getAsDouble(), true, JOYSTICK_DEADBAND)
+													* MAX_SPEED
+													* translationSpeedEntry.getDouble(1.0),
+											SwerveMath.applyDeadband(strafe.getAsDouble(), true, JOYSTICK_DEADBAND)
+													* MAX_SPEED
+													* translationSpeedEntry.getDouble(1.0));
+							if (DriverStation.getAlliance().orElse(Alliance.Blue) == Alliance.Red) {
+								constrainedTranslation = constrainedTranslation.unaryMinus();
+							}
+							if (flipTranslationEntry.getBoolean(false)) {
+								constrainedTranslation = constrainedTranslation.unaryMinus();
+							}
+							drive(constrainedTranslation, constrainedRotation, true);
+						})
+				.withName("DriveJoystick");
 	}
 
 	// this might need to be put in its own file due to complexity

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "photonlib.json",
     "name": "photonlib",
-    "version": "v2024.2.9",
+    "version": "v2024.3.1",
     "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
     "frcYear": "2024",
     "mavenUrls": [
@@ -14,7 +14,7 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photonlib-cpp",
-            "version": "v2024.2.9",
+            "version": "v2024.3.1",
             "libName": "photonlib",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -29,7 +29,7 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photontargeting-cpp",
-            "version": "v2024.2.9",
+            "version": "v2024.3.1",
             "libName": "photontargeting",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -46,12 +46,12 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photonlib-java",
-            "version": "v2024.2.9"
+            "version": "v2024.3.1"
         },
         {
             "groupId": "org.photonvision",
             "artifactId": "photontargeting-java",
-            "version": "v2024.2.9"
+            "version": "v2024.3.1"
         }
     ]
 }


### PR DESCRIPTION
Ignore the commit message- After testing on Monday 6/10, it was working. Not sure what changed, though, which might be worth investigating.

Main purpose is to have a mode where it rotates towards an AprilTag for use at outreach. The control is done in Shuffleboard to avoid accidental activations. Not terribly well tuned, but it should still be a decently interesting demo.